### PR TITLE
Dropdown 컴포넌트 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@
 #### `SelectInput`
 
 [SelectInput 컴포넌트 #2](https://github.com/second-hand-team-04/second-hand-max-fe/issues/2)
+
+#### `Dropdown`
+
+[Dropdown 컴포넌트 #6](https://github.com/second-hand-team-04/second-hand-max-fe/issues/6)
+
+### Hooks
+
+#### `useViewportIntersection`
+
+- Viewport을 고려하여 위치를 동적으로 변경해야할 수 있는 경우(Ex: `SelectInput`과 `Dropdown`)를 위해 viewport의 "left"/"right"과의 중첩 여부를 알려줌.
+- IntersectionObserver API를 사용.

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -1,0 +1,64 @@
+import { ReactNode, useRef, useState } from "react";
+import { styled } from "styled-components";
+import useViewportIntersection from "../hooks/useViewportIntersection";
+
+type Props = {
+  buttonContent: ReactNode;
+  children: ReactNode;
+};
+
+export default function Dropdown({ buttonContent, children }: Props) {
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const intersectingSide = useViewportIntersection(dropdownRef);
+
+  const onToggleIsOpen = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <StyledDropdown>
+      <DropdownButton {...{ type: "button", onClick: onToggleIsOpen }}>
+        {buttonContent}
+      </DropdownButton>
+
+      {isOpen && children && (
+        <DropdownList
+          {...{
+            ref: dropdownRef,
+            $intersectingSide: intersectingSide,
+            onClick: () => setIsOpen(false),
+          }}>
+          {children}
+        </DropdownList>
+      )}
+    </StyledDropdown>
+  );
+}
+
+const StyledDropdown = styled.div`
+  display: inline-block;
+  position: relative;
+  transform: translateX(880px);
+`;
+
+const DropdownButton = styled.button`
+  padding: 8px;
+  display: flex;
+  align-items: center;
+`;
+
+const DropdownList = styled.ul<{ $intersectingSide: "left" | "right" | null }>`
+  width: 240px;
+  position: absolute;
+  top: 48px;
+  left: ${({ $intersectingSide }) =>
+    $intersectingSide === "left" || $intersectingSide === null
+      ? "16px"
+      : "auto"};
+  right: ${({ $intersectingSide }) => $intersectingSide === "right" && "16px"};
+  background-color: ${({ theme: { color } }) => color.white};
+  border-radius: 12px;
+  box-shadow: 0px 4px 4px 0px #00000040;
+`;

--- a/src/components/common/Dropdown/DropdownItem.tsx
+++ b/src/components/common/Dropdown/DropdownItem.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import { styled } from "styled-components";
+
+type Props = {
+  onClick: () => void;
+  children: ReactNode;
+};
+
+export default function DropdownItem({ onClick, children }: Props) {
+  return <StyledDropdownItem onClick={onClick}>{children}</StyledDropdownItem>;
+}
+
+const StyledDropdownItem = styled.li`
+  padding: 16px;
+  font: ${({ theme: { font } }) => font.availableDefault16};
+  text-align: left;
+  cursor: pointer;
+  &:not(:last-child) {
+    border-bottom: 0.8px solid var(--neutral-border, rgba(179, 179, 179, 0.39));
+  }
+`;

--- a/src/components/common/Dropdown/index.ts
+++ b/src/components/common/Dropdown/index.ts
@@ -1,0 +1,2 @@
+export { default as Dropdown } from "./Dropdown";
+export { default as DropdownItem } from "./DropdownItem";

--- a/src/components/common/hooks/useViewportIntersection.tsx
+++ b/src/components/common/hooks/useViewportIntersection.tsx
@@ -1,0 +1,38 @@
+import { RefObject, useEffect, useState } from "react";
+
+export default function useViewportIntersection(
+  elementRef: RefObject<Element>
+) {
+  const [intersectingSide, setIntersectingSide] = useState<
+    "left" | "right" | null
+  >(null);
+
+  const updateEntry = ([entry]: IntersectionObserverEntry[]) => {
+    if (entry.isIntersecting) {
+      const { left, right } = entry.boundingClientRect;
+      if (left <= 0) {
+        setIntersectingSide("left");
+      } else if (right >= window.innerWidth) {
+        setIntersectingSide("right");
+      }
+      return;
+    }
+
+    setIntersectingSide(null);
+  };
+
+  useEffect(() => {
+    const elementNode = elementRef?.current;
+
+    if (!elementNode) return;
+
+    const observerOptions = {};
+    const observer = new IntersectionObserver(updateEntry, observerOptions);
+    observer.observe(elementNode);
+
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef?.current]);
+
+  return intersectingSide;
+}


### PR DESCRIPTION
## Issues
- #6 

## What is this PR? 👓
- 액션(click)을 취할 수 있는 Dropdown 컴포넌트 구현.

## Key changes 🔑
- Dropdown 패널의 위치(왼쪽/오른쪽)를 동적으로 정해줄 수 있는 `useViewportIntersection` custom hook 적용.

## To reviewers 👋
- `useViewportIntersection`을 적용하긴 했는데 버그가 있습니다.
  - 대상 element가 viewport의 오른쪽과 중첩이 될 때, 처음에는 중첩된 상태로 그려지고 Dropdown을 닫았다가 다시 열때 동적으로 왼쪽으로 그려집니다. 그리고 다시 닫았다가 다시 열면 또 중첩이 되는 반복적인 현상입니다.
